### PR TITLE
fix p variable bug in the run and measure function

### DIFF
--- a/2019_01_27_Warsaw_QC_meetup/introduction_to_forest.ipynb
+++ b/2019_01_27_Warsaw_QC_meetup/introduction_to_forest.ipynb
@@ -218,7 +218,7 @@
     "    if qc is None:\n",
     "        qc = get_qc(str(n_qubits)+'q-qvm')\n",
     "    \n",
-    "    result = qc.run_and_measure(p, trials=trials)\n",
+    "    result = qc.run_and_measure(program, trials=trials)\n",
     "    if trials <= 100:\n",
     "        for i in range(n_qubits):\n",
     "            print(result[i])\n",


### PR DESCRIPTION
There was a mistake, and inner scope `program` var was never used. The notebook only worked because there was a coincidence - inner `p` var name reflected outer scope `p` for Program.